### PR TITLE
add Appendix G for WME (#7)

### DIFF
--- a/manual/sections/appendix-g.adoc
+++ b/manual/sections/appendix-g.adoc
@@ -1,9 +1,3 @@
-== APPENDIX G: REVISION HISTORY
+== APPENDIX G: WIS2 MONITORING EVENTS
 
-[cols="12,18,12,12,46",options="header"]
-|===
-|Date |Release |Proposed by | Primary clauses modified |Approved by
-|May 2023| 1.0.0 | INFCOM | Initial approval for publication (2023 edition)| Cg-19
-|June 2024| 1.1.0 | INFCOM | Sections 2.5, 3.7, 4.5, 4.6, 4.7 and Part VI:  To update procedures, guidance or requirements for WIS Centres, Global Caches,
-Global Discovery Catalogues, managing operations of WIS, and information management. Addition of Appendices D, E and F on WIS2 Topic Hierarchy, WIS2 Notification Message, and WCMP2.| EC-78
-|===
+https://wmo-im.github.io/wis2-monitoring-events/standard/wis2-monitoring-events-DRAFT.html

--- a/manual/sections/appendix-h.adoc
+++ b/manual/sections/appendix-h.adoc
@@ -1,0 +1,9 @@
+== APPENDIX H: REVISION HISTORY
+
+[cols="12,18,12,12,46",options="header"]
+|===
+|Date |Release |Proposed by | Primary clauses modified |Approved by
+|May 2023| 1.0.0 | INFCOM | Initial approval for publication (2023 edition)| Cg-19
+|June 2024| 1.1.0 | INFCOM | Sections 2.5, 3.7, 4.5, 4.6, 4.7 and Part VI:  To update procedures, guidance or requirements for WIS Centres, Global Caches,
+Global Discovery Catalogues, managing operations of WIS, and information management. Addition of Appendices D, E and F on WIS2 Topic Hierarchy, WIS2 Notification Message, and WCMP2.| EC-78
+|===


### PR DESCRIPTION
Fixes #7.

Note that given we have not published the Manual from GitHub/asciidoc as of yet, this PR appendix inclusion of specification follows the existing pattern of other appendices/links in this repo.